### PR TITLE
Missing pointnav_weights.pth in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The weights for MobileSAM, GroundingDINO, and PointNav must be saved to the `dat
 - `mobile_sam.pt`:  https://github.com/ChaoningZhang/MobileSAM
 - `groundingdino_swint_ogc.pth`: https://github.com/IDEA-Research/GroundingDINO
 - `yolov7-e6e.pt`: https://github.com/WongKinYiu/yolov7
-- `pointnav_weights.pth`:
+- `pointnav_weights.pth`: **where to find this file?**
 
 ## :arrow_forward: Evaluation within Habitat
 Run the following to evaluate on the HM3D dataset:


### PR DESCRIPTION
This is not a PR. I'd like to open an issue, but there is no such option.
The issue is one of the links for downloading weights is missing. 
Thank you for looking into this!