### PR TITLE
Fixed cv2/numpy bug + Better Setup & Usage Instructions + Fixed pointnav_policy_path for Reality

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Understanding how humans leverage semantic knowledge to navigate unfamiliar envi
 
 ## :hammer_and_wrench: Installation
 
-### Getting Started
+### Getting Started: Environment
 
 Create the conda environment:
 ```bash
@@ -50,7 +50,6 @@ If you are using habitat and are doing simulation experiments, install this repo
 ```bash
 pip install -e .[habitat]
 ```
-Also clone and install [habitat-lab](https://github.com/facebookresearch/habitat-lab) on the same environment
 
 If you are using the Spot robot, install this repo into your env with the following:
 ```bash
@@ -59,23 +58,27 @@ pip install -e .[reality]
 
 Clone the below dependencies into the root directory of this repo:
 ```bash
-git clone git@github.com:IDEA-Research/GroundingDINO.git
-git clone git@github.com:WongKinYiu/yolov7.git  # if using YOLOv7
+git clone https://github.com/IDEA-Research/GroundingDINO.git
+git clone https://github.com/WongKinYiu/yolov7.git  # if using YOLOv7
+git clone https://github.com/facebookresearch/habitat-lab
 ```
 Follow the original install directions for GroundingDINO, which can be found here: https://github.com/IDEA-Research/GroundingDINO.
 
 Nothing needs to be done for YOLOv7, but it needs to be cloned into the repo.
 
+Follow the original install directions for Habitat-lab, which can be found here: https://github.com/facebookresearch/habitat-lab.
+
+
 The following pip install's will also be required:
 
-```
+```bash
 pip install hydra-core --upgrade
-pip install numba # Try not to downgrade numpy during this instalation if possible
+pip install numba # Try not to downgrade numpy during this instalation if possible. Go to https://numba.readthedocs.io/en/stable/user/installing.html for more installation instructions.
 pip install gym
-pip install timm==0.6.12 # Ignore any issues abotu incompatibility
+pip install timm==0.6.12 # Ignore any issues about incompatibility. Need version >=0.6.12 for depth model.
 ```
 
-### Installing GroundingDINO (Only if using conda-installed CUDA)
+#### Troubleshooting: Installing GroundingDINO (Only if using conda-installed CUDA)
 Only attempt if the installation instructions in the GroundingDINO repo do not work.
 
 To install GroundingDINO, you will need `CUDA_HOME` set as an environment variable. If you would like to install a certain version of CUDA that is compatible with the one used to compile your version of pytorch, and you are using conda, you can run the following commands to install CUDA and set `CUDA_HOME`:
@@ -96,7 +99,23 @@ ln -s ${CONDA_PREFIX}/lib/python3.9/site-packages/nvidia/cusolver/include/*  ${C
 export CUDA_HOME=${CONDA_PREFIX}
 ```
 
-## :dart: Downloading the HM3D dataset
+
+### :weight_lifting: Downloading weights for various models
+The weights for MobileSAM, GroundingDINO, and PointNav must be saved to the `data/` directory. The weights can be downloaded from the following links:
+- `mobile_sam.pt`:  https://github.com/ChaoningZhang/MobileSAM
+- `groundingdino_swint_ogc.pth`: https://github.com/IDEA-Research/GroundingDINO
+- `yolov7-e6e.pt`: https://github.com/WongKinYiu/yolov7
+- `pointnav_weights.pth`: included inside the [data](data) subdirectory
+
+```bash
+cd data/
+wget -q https://github.com/ChaoningZhang/MobileSAM/blob/master/weights/mobile_sam.pt
+wget -q https://github.com/IDEA-Research/GroundingDINO/releases/download/v0.1.0-alpha/groundingdino_swint_ogc.pth
+wget -q https://github.com/WongKinYiu/yolov7/releases/download/v0.1/yolov7-e6e.pt
+```
+
+
+### :dart: Dataset: Downloading the HM3D dataset
 
 ### Matterport
 First, set the following variables during installation (don't need to put in .bashrc):
@@ -112,7 +131,7 @@ DATA_DIR=</path/to/vlfm/data>
 HM3D_OBJECTNAV=https://dl.fbaipublicfiles.com/habitat/data/datasets/objectnav/hm3d/v1/objectnav_hm3d_v1.zip
 ```
 
-### Clone and install habitat-lab, then download datasets
+### Make sure that you have cloned and installed *habitat-lab*, then download datasets
 *Ensure that the correct conda environment is activated!!*
 ```bash
 # Download HM3D 3D scans (scenes_dataset)
@@ -133,13 +152,6 @@ mv objectnav_hm3d_v1 $DATA_DIR/datasets/objectnav/hm3d/v1 &&
 rm objectnav_hm3d_v1.zip
 ```
 
-## :weight_lifting: Downloading weights for various models
-The weights for MobileSAM, GroundingDINO, and PointNav must be saved to the `data/` directory. The weights can be downloaded from the following links:
-- `mobile_sam.pt`:  https://github.com/ChaoningZhang/MobileSAM
-- `groundingdino_swint_ogc.pth`: https://github.com/IDEA-Research/GroundingDINO
-- `yolov7-e6e.pt`: https://github.com/WongKinYiu/yolov7
-- `pointnav_weights.pth`: included inside the [data](data) subdirectory
-
 ## :arrow_forward: Evaluation within Habitat
 To run evaluation, various models must be loaded in the background first. This only needs to be done once by running the following command:
 ```bash
@@ -156,6 +168,19 @@ To evaluate on MP3D, run the following:
 ```bash
 python -m vlfm.run habitat.dataset.data_path=data/datasets/objectnav/mp3d/val/val.json.gz
 ```
+
+## :arrow_forward: Run on Spot
+To run program on spot:
+
+To edit goal object edit env.goal in `config\experiments\reality.yaml`
+
+```bash
+export SPOT_ADMIN_PW=<YOUR_SPOT_ADMIN_PW>
+export SPOT_IP=<SPOT_IP>
+
+python -m vlfm.reality.run_bdsw_objnav_env
+```
+
 
 ## :newspaper: License
 

--- a/README.md
+++ b/README.md
@@ -43,15 +43,21 @@ conda_env_name=vlfm
 conda create -n $conda_env_name python=3.9 -y &&
 conda activate $conda_env_name
 ```
+
+Check compiled cuda version/available cuda version and install the closest available corresponding torch. *This will be important for successful GroundingDINO installation*
+
 If you are using habitat and are doing simulation experiments, install this repo into your env with the following:
 ```bash
 pip install -e .[habitat]
 ```
+Also clone and install [habitat-lab](https://github.com/facebookresearch/habitat-lab) on the same environment
+
 If you are using the Spot robot, install this repo into your env with the following:
 ```bash
 pip install -e .[reality]
 ```
-Install all the dependencies:
+
+Clone the below dependencies into the root directory of this repo:
 ```bash
 git clone git@github.com:IDEA-Research/GroundingDINO.git
 git clone git@github.com:WongKinYiu/yolov7.git  # if using YOLOv7
@@ -59,6 +65,15 @@ git clone git@github.com:WongKinYiu/yolov7.git  # if using YOLOv7
 Follow the original install directions for GroundingDINO, which can be found here: https://github.com/IDEA-Research/GroundingDINO.
 
 Nothing needs to be done for YOLOv7, but it needs to be cloned into the repo.
+
+The following pip install's will also be required:
+
+```
+pip install hydra-core --upgrade
+pip install numba # Try not to downgrade numpy during this instalation if possible
+pip install gym
+pip install timm==0.6.12 # Ignore any issues abotu incompatibility
+```
 
 ### Installing GroundingDINO (Only if using conda-installed CUDA)
 Only attempt if the installation instructions in the GroundingDINO repo do not work.

--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@ Run the following to evaluate on the HM3D dataset:
 ```bash
 python -m vlfm.run
 ```
+To run the evaluation and save the video of the simulator:
+```
+python -m vlfm.run habitat_baselines.eval.video_option='["disk"]'
+```
 To evaluate on MP3D, run the following:
 ```bash
 python -m vlfm.run habitat.dataset.data_path=data/datasets/objectnav/mp3d/val/val.json.gz

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Clone the below dependencies into the root directory of this repo:
 git clone https://github.com/IDEA-Research/GroundingDINO.git
 git clone https://github.com/WongKinYiu/yolov7.git  # if using YOLOv7
 git clone https://github.com/facebookresearch/habitat-lab
+git clone https://github.com/naokiyokoyama/bd_spot_wrapper.git
 ```
 Follow the original install directions for GroundingDINO, which can be found here: https://github.com/IDEA-Research/GroundingDINO.
 
@@ -68,6 +69,7 @@ Nothing needs to be done for YOLOv7, but it needs to be cloned into the repo.
 
 Follow the original install directions for Habitat-lab, which can be found here: https://github.com/facebookresearch/habitat-lab.
 
+Follow the original install directions for bd spot wrapper, which can be found here: https://github.com/naokiyokoyama/bd_spot_wrapper.git.
 
 The following pip install's will also be required:
 

--- a/config/experiments/reality.yaml
+++ b/config/experiments/reality.yaml
@@ -8,7 +8,7 @@ defaults:
 
 policy:
     name: "RealityITMPolicyV2"
-    pointnav_policy_path: "data/pointnav_weights.pth"
+    pointnav_policy_path: "data/spot_pointnav_weights.pth"
     depth_image_shape: [212, 240]  # height, width
     pointnav_stop_radius: 0.9
     use_max_confidence: False

--- a/config/experiments/reality.yaml
+++ b/config/experiments/reality.yaml
@@ -8,6 +8,7 @@ defaults:
 
 policy:
     name: "RealityITMPolicyV2"
+    #pointnav_policy_path: "data/pointnav_weights.pth"
     pointnav_policy_path: "data/spot_pointnav_weights.pth"
     depth_image_shape: [212, 240]  # height, width
     pointnav_stop_radius: 0.9

--- a/vlfm/vlm/detections.py
+++ b/vlfm/vlm/detections.py
@@ -211,7 +211,7 @@ def draw_bounding_box(
 
     if color is None:
         # Randomly choose a color from the rainbow colormap (so boxes aren't black)
-        single_pixel = np.array([[np.random.randint(0, 256)]])
+        single_pixel = np.array([[np.random.randint(0, 256, dtype=np.uint8)]])
         single_pixel = cv2.applyColorMap(single_pixel, cv2.COLORMAP_RAINBOW)
 
         # reshape to a single dimensional array

--- a/vlfm/vlm/server_wrapper.py
+++ b/vlfm/vlm/server_wrapper.py
@@ -32,7 +32,8 @@ def host_model(model: Any, name: str, port: int = 5000) -> None:
         payload = request.json
         return jsonify(model.process_payload(payload))
 
-    app.run(host="0.0.0.0", port=port)
+    app.run(host="0.0.0.0", port=port) # app.run(host="localhost", port=port)
+
 
 
 def bool_arr_to_str(arr: np.ndarray) -> str:

--- a/vlfm/vlm/server_wrapper.py
+++ b/vlfm/vlm/server_wrapper.py
@@ -32,7 +32,7 @@ def host_model(model: Any, name: str, port: int = 5000) -> None:
         payload = request.json
         return jsonify(model.process_payload(payload))
 
-    app.run(host="localhost", port=port)
+    app.run(host="0.0.0.0", port=port)
 
 
 def bool_arr_to_str(arr: np.ndarray) -> str:


### PR DESCRIPTION
# Fixed CV2/Numpy Bug:

Bug Source:
```python
single_pixel = cv2.applyColorMap(single_pixel, cv2.COLORMAP_RAINBOW) 
```
Bug:
```python
Error:
cv2.error: OpenCV(4.5.5) D:\a\opencv-python\opencv-python\opencv\modules\imgproc\src\colormap.cpp:736: error: (-5:Bad argument) cv::ColorMap only supports source images of type CV_8UC1 or CV_8UC3 in function 'cv::colormap::ColorMap::operator ()'
```

Bug has been detected in multiple versions of OpenCV(4.5 to 4.8) and has been fixed in detection.py

# Environment setup

Environment setup is missing certain libraries and some details which has been added + fixed

Issues: #34 , 

# Usage Instructions

Better instructions for usage on simulator and on SPOT.

Issues: #29 , #26

# pointnav_policy_path for reality

pointnav_policy_path for reality on spot was incorrect and has now been fixed.