### PR TITLE
Change to new RAI Institute copyright

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 name: Docker - Build VLFM Docker
 

--- a/.github/workflows/pre_commit.yml
+++ b/.github/workflows/pre_commit.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 name: Pre-Commit
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,5 @@
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
+
 # Copyright [2023] Boston Dynamics AI Institute, Inc.
 
 name: VLFM CI

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 repos:
 - repo: https://github.com/charliermarsh/ruff-pre-commit

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023-2024 Boston Dynamics AI Institute LLC
+Copyright (c) 2023-2024 Robotics and AI Institute LLC dba RAI Institute
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved. -->
+
 <p align="center">
   <img src="docs/teaser_v1.jpg" width="700">
   <h1 align="center">VLFM: Vision-Language Frontier Maps for Zero-Shot Semantic Navigation</h1>

--- a/config/experiments/reality.yaml
+++ b/config/experiments/reality.yaml
@@ -1,6 +1,6 @@
 # @package _global_
 
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 defaults:
   - /policy: vlfm_config_base

--- a/config/experiments/ver_pointnav.yaml
+++ b/config/experiments/ver_pointnav.yaml
@@ -1,6 +1,6 @@
 # @package _global_
 
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 defaults:
   - /tasks: pointnav_depth_hm3d

--- a/config/experiments/vlfm_objectnav_hm3d.yaml
+++ b/config/experiments/vlfm_objectnav_hm3d.yaml
@@ -1,6 +1,6 @@
 # @package _global_
 
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 defaults:
   - /habitat_baselines: habitat_baselines_rl_config_base

--- a/config/tasks/pointnav_depth_hm3d.yaml
+++ b/config/tasks/pointnav_depth_hm3d.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 # @package _global_
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 FROM ubuntu:22.04
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,5 @@
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
+
 # Copyright [2023] Boston Dynamics AI Institute, Inc.
 
 [build-system]

--- a/scripts/eval_dummy_policy.sh
+++ b/scripts/eval_dummy_policy.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
+
 # Copyright [2023] Boston Dynamics AI Institute, Inc.
 
 python -um zsos.run \

--- a/scripts/eval_itm_policy.sh
+++ b/scripts/eval_itm_policy.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
+
 # Copyright [2023] Boston Dynamics AI Institute, Inc.
 
 python -um vlfm.run \

--- a/scripts/eval_oracle_fbe_policy.sh
+++ b/scripts/eval_oracle_fbe_policy.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
+
 # Copyright [2023] Boston Dynamics AI Institute, Inc.
 
 python -um zsos.run \

--- a/scripts/launch_vlm_servers.sh
+++ b/scripts/launch_vlm_servers.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
+
 # Copyright [2023] Boston Dynamics AI Institute, Inc.
 
 # Ensure you have 'export VLFM_PYTHON=<PATH_TO_PYTHON>' in your .bashrc, where

--- a/scripts/parse_jsons.py
+++ b/scripts/parse_jsons.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import argparse
 import json

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
+
 # Copyright [2023] Boston Dynamics AI Institute, Inc.
 
 from setuptools import setup

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
 # Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
-# Copyright [2023] Boston Dynamics AI Institute, Inc.
-
 from setuptools import setup
 
 setup()

--- a/test/test_setup.py
+++ b/test/test_setup.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import os
 

--- a/test/test_visualization.py
+++ b/test/test_visualization.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import os
 

--- a/vlfm/__init__.py
+++ b/vlfm/__init__.py
@@ -1,1 +1,1 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.

--- a/vlfm/mapping/base_map.py
+++ b/vlfm/mapping/base_map.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from typing import Any, List
 

--- a/vlfm/mapping/frontier_map.py
+++ b/vlfm/mapping/frontier_map.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from typing import List, Tuple
 

--- a/vlfm/mapping/object_point_cloud_map.py
+++ b/vlfm/mapping/object_point_cloud_map.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from typing import Dict, Union
 

--- a/vlfm/mapping/obstacle_map.py
+++ b/vlfm/mapping/obstacle_map.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from typing import Any, Union
 

--- a/vlfm/mapping/traj_visualizer.py
+++ b/vlfm/mapping/traj_visualizer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from typing import Any, List, Union
 

--- a/vlfm/mapping/value_map.py
+++ b/vlfm/mapping/value_map.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import glob
 import json

--- a/vlfm/measurements/traveled_stairs.py
+++ b/vlfm/measurements/traveled_stairs.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from dataclasses import dataclass
 from typing import Any, List

--- a/vlfm/obs_transformers/resize.py
+++ b/vlfm/obs_transformers/resize.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import copy
 from dataclasses import dataclass

--- a/vlfm/obs_transformers/utils.py
+++ b/vlfm/obs_transformers/utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from typing import Tuple
 

--- a/vlfm/policy/__init__.py
+++ b/vlfm/policy/__init__.py
@@ -1,1 +1,1 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.

--- a/vlfm/policy/action_replay_policy.py
+++ b/vlfm/policy/action_replay_policy.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import os
 from typing import Any, List

--- a/vlfm/policy/base_objectnav_policy.py
+++ b/vlfm/policy/base_objectnav_policy.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import os
 from dataclasses import dataclass, fields

--- a/vlfm/policy/base_policy.py
+++ b/vlfm/policy/base_policy.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from typing import Any, Generator
 

--- a/vlfm/policy/habitat_policies.py
+++ b/vlfm/policy/habitat_policies.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from dataclasses import dataclass
 from typing import Any, Dict, Union

--- a/vlfm/policy/itm_policy.py
+++ b/vlfm/policy/itm_policy.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import os
 from typing import Any, Dict, List, Tuple, Union

--- a/vlfm/policy/reality_policies.py
+++ b/vlfm/policy/reality_policies.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from dataclasses import dataclass
 from typing import Any, Dict, List, Union

--- a/vlfm/policy/utils/__init__.py
+++ b/vlfm/policy/utils/__init__.py
@@ -1,1 +1,1 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.

--- a/vlfm/policy/utils/acyclic_enforcer.py
+++ b/vlfm/policy/utils/acyclic_enforcer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from typing import Any, Set
 

--- a/vlfm/policy/utils/non_habitat_policy/__init__.py
+++ b/vlfm/policy/utils/non_habitat_policy/__init__.py
@@ -1,1 +1,1 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.

--- a/vlfm/policy/utils/non_habitat_policy/nh_pointnav_policy.py
+++ b/vlfm/policy/utils/non_habitat_policy/nh_pointnav_policy.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from typing import Dict, Optional, Tuple
 

--- a/vlfm/policy/utils/non_habitat_policy/resnet.py
+++ b/vlfm/policy/utils/non_habitat_policy/resnet.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 
 # Adapted from:

--- a/vlfm/policy/utils/non_habitat_policy/rnn_state_encoder.py
+++ b/vlfm/policy/utils/non_habitat_policy/rnn_state_encoder.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 
 # Adapted from:

--- a/vlfm/policy/utils/pointnav_policy.py
+++ b/vlfm/policy/utils/pointnav_policy.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from typing import Any, Dict, Tuple, Union
 

--- a/vlfm/reality/bdsw_nav_env.py
+++ b/vlfm/reality/bdsw_nav_env.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import numpy as np
 import torch

--- a/vlfm/reality/objectnav_env.py
+++ b/vlfm/reality/objectnav_env.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import os
 import time

--- a/vlfm/reality/pointnav_env.py
+++ b/vlfm/reality/pointnav_env.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import time
 from typing import Any, Dict, Optional, Tuple, Union

--- a/vlfm/reality/robots/base_robot.py
+++ b/vlfm/reality/robots/base_robot.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from typing import Dict, List, Tuple
 

--- a/vlfm/reality/robots/bdsw_robot.py
+++ b/vlfm/reality/robots/bdsw_robot.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from typing import Any, Dict, List, Tuple
 

--- a/vlfm/reality/robots/camera_ids.py
+++ b/vlfm/reality/robots/camera_ids.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 
 class SpotCamIds:

--- a/vlfm/reality/run_bdsw_objnav_env.py
+++ b/vlfm/reality/run_bdsw_objnav_env.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import time
 

--- a/vlfm/run.py
+++ b/vlfm/run.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import os
 

--- a/vlfm/semexp_env/eval.py
+++ b/vlfm/semexp_env/eval.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import os
 import time

--- a/vlfm/semexp_env/objnav_gibson_vlfm.yaml
+++ b/vlfm/semexp_env/objnav_gibson_vlfm.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 ENVIRONMENT:
   MAX_EPISODE_STEPS: 500

--- a/vlfm/utils/episode_stats_logger.py
+++ b/vlfm/utils/episode_stats_logger.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import os
 from typing import Any, Dict

--- a/vlfm/utils/generate_dummy_policy.py
+++ b/vlfm/utils/generate_dummy_policy.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import torch
 

--- a/vlfm/utils/geometry_utils.py
+++ b/vlfm/utils/geometry_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import math
 from typing import Tuple

--- a/vlfm/utils/habitat_visualizer.py
+++ b/vlfm/utils/habitat_visualizer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from typing import Any, Dict, List, Optional, Tuple
 

--- a/vlfm/utils/img_utils.py
+++ b/vlfm/utils/img_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from typing import List, Tuple, Union
 

--- a/vlfm/utils/log_saver.py
+++ b/vlfm/utils/log_saver.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import json
 import os

--- a/vlfm/utils/visualization.py
+++ b/vlfm/utils/visualization.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from typing import List
 

--- a/vlfm/utils/vlfm_trainer.py
+++ b/vlfm/utils/vlfm_trainer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import os
 from collections import defaultdict

--- a/vlfm/vlm/__init__.py
+++ b/vlfm/vlm/__init__.py
@@ -1,1 +1,1 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.

--- a/vlfm/vlm/blip2.py
+++ b/vlfm/vlm/blip2.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from typing import Any, Optional
 

--- a/vlfm/vlm/blip2itm.py
+++ b/vlfm/vlm/blip2itm.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from typing import Any, Optional
 

--- a/vlfm/vlm/coco_classes.py
+++ b/vlfm/vlm/coco_classes.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 COCO_CLASSES = [
     "person",

--- a/vlfm/vlm/detections.py
+++ b/vlfm/vlm/detections.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from typing import List, Optional, Tuple
 

--- a/vlfm/vlm/fiber.py
+++ b/vlfm/vlm/fiber.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import numpy as np
 import torch

--- a/vlfm/vlm/grounding_dino.py
+++ b/vlfm/vlm/grounding_dino.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from typing import Optional
 

--- a/vlfm/vlm/sam.py
+++ b/vlfm/vlm/sam.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import os
 from typing import Any, List, Optional

--- a/vlfm/vlm/server_wrapper.py
+++ b/vlfm/vlm/server_wrapper.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import base64
 import os

--- a/vlfm/vlm/yolov7.py
+++ b/vlfm/vlm/yolov7.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2023 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import sys
 from typing import List, Optional


### PR DESCRIPTION
Automated update to fix copyright headers with new organization name.

"Boston Dynamics AI Institute LLC" has been changed to "Robotics and AI Institute LLC" or "RAI Institute" for short.

Note that the date-stamps in the copyright headers have been preserved. Only files with existing copyrights have been modified.

This PR was created automatically.